### PR TITLE
typo fix and settings that my IDE needed to work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ cmake-build-*/
 
 # IntelliJ
 out/
+lib/
 
 # mpeltonen/sbt-idea plugin
 .idea_modules/

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" addBOMForNewFiles="with NO BOM" />
+</project>

--- a/KidneyExchange/src/main/KidneyExchange/KidneyExchange.java
+++ b/KidneyExchange/src/main/KidneyExchange/KidneyExchange.java
@@ -8,7 +8,7 @@ import java.util.HashMap;
 public class KidneyExchange {
     private static final int DEFAULT_NUM_HOSPITALS = 3;
     private static final int DEFAULT_NUM_PAIRS = 5;
-    private static final int DEFAULT_MAX_SURGEERIES = 5;
+    private static final int DEFAULT_MAX_SURGERIES = 5;
     private static final int DEFAULT_NUM_ROUNDS = 4;
 
     // Main function controlling behavior of kidney exchange
@@ -25,7 +25,7 @@ public class KidneyExchange {
         // Create Hospitals participating in Kidney Exchange
         int numHospitals = (cli.numHospitals == null) ? DEFAULT_NUM_HOSPITALS : cli.numHospitals;
         int numPairs = (cli.numPairs == null) ? DEFAULT_NUM_PAIRS : cli.numPairs;
-        int maxSurgeries = (cli.maxSurgeries == null) ? DEFAULT_MAX_SURGEERIES : cli.maxSurgeries;
+        int maxSurgeries = (cli.maxSurgeries == null) ? DEFAULT_MAX_SURGERIES : cli.maxSurgeries;
 
         Hospital[] hospitals = new Hospital[numHospitals];
         for(int i=0; i < numHospitals; i++) {

--- a/KidneyExchangeTest/KidneyExchangeTest.iml
+++ b/KidneyExchangeTest/KidneyExchangeTest.iml
@@ -21,5 +21,6 @@
     </orderEntry>
     <orderEntry type="module" module-name="KidneyExchange" />
     <orderEntry type="library" name="org.choco-solver:choco-solver:4.0.9" level="project" />
+    <orderEntry type="library" name="com.beust:jcommander:1.72" level="project" />
   </component>
 </module>


### PR DESCRIPTION
Fixed typo in the spelling of SURGERIES.

My IntelliJ would not work without the slight modifications below. I tried not to modify any of the IntelliJ configuration files, but I am hoping that the following modifications are harmless.

I was going to add `.idea/encodings.xml` to `.gitignore`, but it seemed harmless, so I added it here.