### PR TITLE
Tests and prints

### DIFF
--- a/KidneyExchange/src/main/KidneyExchange/Hospital.java
+++ b/KidneyExchange/src/main/KidneyExchange/Hospital.java
@@ -48,7 +48,11 @@ public class Hospital {
         StringBuilder s = new StringBuilder();
         s.append("Hospital: " + hospitalId + ", maxSurgeries=" + maxSurgeries + "\n");
         for(ExchangePair pair: pairs) {
-            s.append(pair.toString() + "\n");
+            if(pair.getCurrentHospital() == hospitalId) {
+                s.append(pair.toString() + "\n");
+            } else {
+                s.append(pair.toString() + " (hospital: " + pair.getCurrentHospital() + ")\n");
+            }
         }
         return s.toString();
     }

--- a/KidneyExchange/src/main/KidneyExchange/KidneyExchange.java
+++ b/KidneyExchange/src/main/KidneyExchange/KidneyExchange.java
@@ -139,9 +139,12 @@ public class KidneyExchange {
                                 if(pair.getCurrentHospital() != hospital.getHospitalId()) {
                                     System.out.println("Moving " + pair.toString() + " from hospital " +
                                             pair.getCurrentHospital() + " to hospital " + hospital.getHospitalId());
-                                    // Remove knowledge of pair from current hospital and move to new hospital
-                                    Hospital currentHospital = hospitals[pair.getCurrentHospital() - 1];
-                                    currentHospital.removePair(pair);
+                                    // Remove knowledge of pair from all hospitals except new hospital
+                                    for(Hospital h: hospitals) {
+                                        if(h.getHospitalId() != hospital.getHospitalId()) {
+                                            h.removePair(pair);
+                                        }
+                                    }
                                     pair.setCurrentHospital(hospital.getHospitalId());
                                 }
                             }
@@ -151,7 +154,7 @@ public class KidneyExchange {
                 }
                 // Inform higher ranked peer of unmatched pairs to be accounted for in next round.
                 // In other words, all peer information will be distributed after numHospital rounds.
-                if(hospital.getHospitalId() != 1 && i < hospitals.length) {
+                if(hospital.getHospitalId() != 1) {
                     Hospital peer = hospitals[hospital.getHospitalId() - 2];
                     for(ExchangePair pair: hospital.getPairs()) {
                         if(!peer.hasPair(pair)) {

--- a/KidneyExchange/src/main/KidneyExchange/KidneyExchange.java
+++ b/KidneyExchange/src/main/KidneyExchange/KidneyExchange.java
@@ -42,10 +42,10 @@ public class KidneyExchange {
 
         // Run the kidney exchange for some fixed number of rounds
         int numRounds = (cli.numRounds == null) ? DEFAULT_NUM_ROUNDS : cli.numRounds;
-        runKidneyExchange(numRounds, hospitals);
+        runKidneyExchange(numRounds, hospitals, true);
     }
 
-    private static void runKidneyExchange(int numRounds, Hospital[] hospitals) {
+    public static void runKidneyExchange(int numRounds, Hospital[] hospitals, boolean incremental) {
         // Each round of the kidney exchange works as follows:
         //     1. Each hospital creates a directed graph amongst ExchangePairs that it
         //        is aware of, where an edge from pair i to pair j indicates that pair
@@ -64,18 +64,20 @@ public class KidneyExchange {
             System.out.println("\nRound: " + i + "\n");
             for(Hospital hospital : hospitals) {
                 // INCREMENTAL SETTING #1: Add/remove random pair from hospital 2/5 of the time
-                switch(KidneyExchangeHelper.rand.nextInt(5)) {
-                    case 1: // add pair
-                        KidneyExchangeHelper.addRandomExchangePair(hospital);
-                        break;
-                    case 2: // remove random pair that hospital is aware of
-                        if(hospital.getSize() > 0) {
-                            ExchangePair randPair = KidneyExchangeHelper.delRandomExchangePair(hospital);
-                            for (Hospital h : hospitals) {
-                                h.removePair(randPair);
+                if(incremental) {
+                    switch (KidneyExchangeHelper.rand.nextInt(5)) {
+                        case 1: // add pair
+                            KidneyExchangeHelper.addRandomExchangePair(hospital);
+                            break;
+                        case 2: // remove random pair that hospital is aware of
+                            if (hospital.getSize() > 0) {
+                                ExchangePair randPair = KidneyExchangeHelper.delRandomExchangePair(hospital);
+                                for (Hospital h : hospitals) {
+                                    h.removePair(randPair);
+                                }
                             }
-                        }
-                        break;
+                            break;
+                    }
                 }
                 // Print Hospital
                 System.out.print(hospital);
@@ -94,7 +96,8 @@ public class KidneyExchange {
                                                                                                             graph);
 
                 // INCREMENTAL SETTING #2: Simulate matched pair dropping out 1/8 of the time
-                if(matches != null && matches.size() > 0 && KidneyExchangeHelper.rand.nextInt(8) == 7) {
+                if(matches != null && matches.size() > 0 && incremental &&
+                        KidneyExchangeHelper.rand.nextInt(8) == 7) {
                     ExchangePair dropout = KidneyExchangeHelper.delRandomMatchedPair(matches);
                     System.out.println("\n" + dropout.toString() + " has dropped out of matching.");
                     // Remove pair from all hospitals that are aware of pair

--- a/KidneyExchange/src/main/KidneyExchange/KidneyExchange.java
+++ b/KidneyExchange/src/main/KidneyExchange/KidneyExchange.java
@@ -121,7 +121,7 @@ public class KidneyExchange {
                         }
                         if(localCycle) {
                             // Perform surgeries and remove pairs from all hospitals
-                            System.out.println("----------------");
+                            ConsoleLogger.println("----------------");
                             for (ExchangePair pair : cycle.keySet()) {
                                 ConsoleLogger.println(pair.toString() + " -> " + cycle.get(pair).toString());
                                 for (Hospital h : hospitals) {
@@ -130,7 +130,7 @@ public class KidneyExchange {
                             }
                         } else if(highestRanked) {
                             // Acquire patients from lower ranked hospitals for matching next round.
-                            System.out.println("----------------");
+                            ConsoleLogger.println("----------------");
                             for(ExchangePair pair : cycle.keySet()) {
                                 if(pair.getCurrentHospital() != hospital.getHospitalId()) {
                                     ConsoleLogger.println("Moving " + pair.toString() + " from hospital " +
@@ -146,7 +146,7 @@ public class KidneyExchange {
                             }
                         }
                     }
-                    System.out.println("----------------");
+                    ConsoleLogger.println("----------------");
                 }
                 // Inform higher ranked peer of unmatched pairs to be accounted for in next round.
                 // In other words, all peer information will be distributed after numHospital rounds.

--- a/KidneyExchange/src/main/KidneyExchange/KidneyExchange.java
+++ b/KidneyExchange/src/main/KidneyExchange/KidneyExchange.java
@@ -81,8 +81,13 @@ public class KidneyExchange {
                 System.out.print(hospital);
                 // Create directed graph from ExchangePairs
                 DirectedGraph graph = KidneyExchangeHelper.createDirectedGraph(hospital);
-                System.out.println("Adjacency List for Hospital " + hospital.getHospitalId() + ":");
-                System.out.print(graph);
+
+                // Adjacency List should be printed when print level is verbose
+                boolean printAdjList = false;
+                if(printAdjList) {
+                    System.out.println("Adjacency List for Hospital " + hospital.getHospitalId() + ":");
+                    System.out.print(graph);
+                }
 
                 // Get list of cycles
                 ArrayList<HashMap<ExchangePair, ExchangePair>> matches = KidneyExchangeHelper.greedyMatches(hospital,
@@ -117,6 +122,7 @@ public class KidneyExchange {
                         }
                         if(localCycle) {
                             // Perform surgeries and remove pairs from all hospitals
+                            System.out.println("----------------");
                             for (ExchangePair pair : cycle.keySet()) {
                                 System.out.println(pair.toString() + " -> " + cycle.get(pair).toString());
                                 for (Hospital h : hospitals) {
@@ -125,15 +131,20 @@ public class KidneyExchange {
                             }
                         } else if(highestRanked) {
                             // Acquire patients from lower ranked hospitals for matching next round.
+                            System.out.println("----------------");
                             for(ExchangePair pair : cycle.keySet()) {
                                 if(pair.getCurrentHospital() != hospital.getHospitalId()) {
                                     System.out.println("Moving " + pair.toString() + " from hospital " +
                                             pair.getCurrentHospital() + " to hospital " + hospital.getHospitalId());
+                                    // Remove knowledge of pair from current hospital and move to new hospital
+                                    Hospital currentHospital = hospitals[pair.getCurrentHospital() - 1];
+                                    currentHospital.removePair(pair);
                                     pair.setCurrentHospital(hospital.getHospitalId());
                                 }
                             }
                         }
                     }
+                    System.out.println("----------------");
                 }
                 // Inform higher ranked peer of unmatched pairs to be accounted for in next round.
                 // In other words, all peer information will be distributed after numHospital rounds.

--- a/KidneyExchange/src/main/KidneyExchange/KidneyExchangeHelper.java
+++ b/KidneyExchange/src/main/KidneyExchange/KidneyExchangeHelper.java
@@ -73,8 +73,9 @@ public class KidneyExchangeHelper {
     public static ArrayList<HashMap<ExchangePair, ExchangePair>> greedyMatches(Hospital hospital) {
         // Create directed graph from ExchangePairs
         DirectedGraph graph = KidneyExchangeHelper.createDirectedGraph(hospital);
-        ConsoleLogger.println("Adjacency List for Hospital " + hospital.getHospitalId() + ":");
-        ConsoleLogger.print(graph);
+        // Print adjacency list only when debugging
+        //ConsoleLogger.println("Adjacency List for Hospital " + hospital.getHospitalId() + ":");
+        //ConsoleLogger.print(graph);
 
         // Greedy matching algorithm is implemented as a variant of the Top Trading Cycle algorithm.
         //     1. Select unmatched node from graph.

--- a/KidneyExchange/src/main/KidneyExchange/KidneyExchangeHelper.java
+++ b/KidneyExchange/src/main/KidneyExchange/KidneyExchangeHelper.java
@@ -73,8 +73,9 @@ public class KidneyExchangeHelper {
     public static ArrayList<HashMap<ExchangePair, ExchangePair>> greedyMatches(Hospital hospital) {
         // Create directed graph from ExchangePairs
         DirectedGraph graph = KidneyExchangeHelper.createDirectedGraph(hospital);
-        System.out.println("Adjacency List for Hospital " + hospital.getHospitalId() + ":");
-        System.out.print(graph);
+        // Prints for debugging purposes
+        //System.out.println("Adjacency List for Hospital " + hospital.getHospitalId() + ":");
+        //System.out.print(graph);
 
         // Greedy matching algorithm is implemented as a variant of the Top Trading Cycle algorithm.
         //     1. Select unmatched node from graph.

--- a/KidneyExchange/src/main/KidneyExchange/KidneyType.java
+++ b/KidneyExchange/src/main/KidneyExchange/KidneyType.java
@@ -1,0 +1,6 @@
+package KidneyExchange;
+
+// Enumerate list of possible kidney types
+public enum KidneyType {
+    A, B, C, D
+}

--- a/KidneyExchange/src/main/KidneyExchange/Participant.java
+++ b/KidneyExchange/src/main/KidneyExchange/Participant.java
@@ -1,10 +1,5 @@
 package KidneyExchange;
 
-// Enumerate list of possible kidney types
-enum KidneyType {
-    A, B, C, D;
-}
-
 public final class Participant {
     private final KidneyType type;
 

--- a/KidneyExchangeTest/src/KidneyExchangeTest.java
+++ b/KidneyExchangeTest/src/KidneyExchangeTest.java
@@ -6,8 +6,7 @@ import org.junit.jupiter.api.Test;
 public class KidneyExchangeTest {
 
     // Test a single round of runKidneyExchange with single hospital
-    @Test
-    public void runKidneyExchangeTest1() {
+    public void runKidneyExchangeTest1(MatchingAlgorithm matchingAlgorithm) {
         int hospitalId = 0;
         int pairId = 0;
         // Create a hospital with 3 surgery slots and add a cycle of length 3
@@ -18,7 +17,7 @@ public class KidneyExchangeTest {
 
         // Run single round of kidney exchange and verify that all patients are removed
         Hospital[] hospitals = { hospital1 };
-        KidneyExchange.runKidneyExchange(1, hospitals,false);
+        KidneyExchange.runKidneyExchange(1, hospitals, matchingAlgorithm, false);
         Assertions.assertEquals(hospital1.getSize(), 0);
 
         // Create another hospital with 2 surgery slots and a cycle of length 3
@@ -29,13 +28,12 @@ public class KidneyExchangeTest {
 
         // Run single round of kidney exchange and verify that no patients are removed
         hospitals[0] = hospital2;
-        KidneyExchange.runKidneyExchange(1, hospitals, false);
+        KidneyExchange.runKidneyExchange(1, hospitals, matchingAlgorithm, false);
         Assertions.assertEquals(hospital2.getSize(), 3);
     }
 
     // Test three rounds of runKidneyExchange with two hospitals that need to collaborate
-    @Test
-    public void runKidneyExchangeTest2() {
+    public void runKidneyExchangeTest2(MatchingAlgorithm matchingAlgorithm) {
         int hospitalId = 0;
         int pairId = 0;
 
@@ -51,14 +49,13 @@ public class KidneyExchangeTest {
         // Neither will be able to match in Round 1, Hospital 1 will acquire pairs in Round 2,
         // pairs will be matched in Round 3
         Hospital[] hospitals = { hospital1, hospital2 };
-        KidneyExchange.runKidneyExchange(3, hospitals, false);
+        KidneyExchange.runKidneyExchange(3, hospitals, matchingAlgorithm, false);
         Assertions.assertEquals(hospital1.getSize(), 0);
         Assertions.assertEquals(hospital2.getSize(), 0);
     }
 
     // Test four rounds of runKidneyExchange with three hospitals and verify that pairs distribute
-    @Test
-    public void runKidneyExchangeTest3() {
+    public void runKidneyExchangeTest3(MatchingAlgorithm matchingAlgorithm) {
         int hospitalId = 0;
         int pairId = 0;
 
@@ -76,15 +73,14 @@ public class KidneyExchangeTest {
         // Hospital 1 will acquire Hospital 3 pair in round 3, pairs will be matched in round 4
         // pairs will be matched in Round 3
         Hospital[] hospitals = { hospital1, hospital2, hospital3 };
-        KidneyExchange.runKidneyExchange(4, hospitals, false);
+        KidneyExchange.runKidneyExchange(4, hospitals, matchingAlgorithm, false);
         Assertions.assertEquals(hospital1.getSize(), 0);
         Assertions.assertEquals(hospital2.getSize(), 0);
         Assertions.assertEquals(hospital3.getSize(), 0);
     }
 
     // Test three rounds of runKidneyExchange and verify that information is distributed when no one can be matched
-    @Test
-    public void runKidneyExchangeTest4() {
+    public void runKidneyExchangeTest4(MatchingAlgorithm matchingAlgorithm) {
         int hospitalId = 0;
         int pairId = 0;
 
@@ -103,7 +99,7 @@ public class KidneyExchangeTest {
 
         // No one will ever be able to match, but by round 3, information will have been fully distributed
         Hospital[] hospitals = { hospital1, hospital2, hospital3 };
-        KidneyExchange.runKidneyExchange(3, hospitals, false);
+        KidneyExchange.runKidneyExchange(3, hospitals, matchingAlgorithm, false);
         Assertions.assertEquals(hospital1.getSize(), 6);
         Assertions.assertEquals(hospital2.getSize(), 4);
         Assertions.assertEquals(hospital3.getSize(), 2);
@@ -139,9 +135,20 @@ public class KidneyExchangeTest {
         // Round 3: Hospital 1 can only perform two surgeries at a time, so will be left with four pairs
         //          Hospital 2 still waits for remaining pair to be requested
         Hospital[] hospitals = { hospital1, hospital2 };
-        KidneyExchange.runKidneyExchange(3, hospitals, false);
+        KidneyExchange.runKidneyExchange(3, hospitals, MatchingAlgorithm.Greedy, false);
         Assertions.assertEquals(hospital1.getSize(), 4);
         Assertions.assertEquals(hospital2.getSize(), 1);
+    }
+
+    @Test
+    public void runKidneyExchangeTests() {
+        for(MatchingAlgorithm matchingAlgorithm: MatchingAlgorithm.values()) {
+            runKidneyExchangeTest1(matchingAlgorithm);
+            runKidneyExchangeTest2(matchingAlgorithm);
+            runKidneyExchangeTest3(matchingAlgorithm);
+            runKidneyExchangeTest4(matchingAlgorithm);
+            //runKidneyExchangeTest5(matchingAlgorithm);
+        }
     }
 
     // Build a scale test to prove that algorithm can scale
@@ -168,7 +175,7 @@ public class KidneyExchangeTest {
 
         Hospital[] hospitals = { hospital1, hospital2 };
         // Hospital 1 will finish after 50 rounds, while Hospital 2 will finish in 25 rounds
-        KidneyExchange.runKidneyExchange(50, hospitals, false);
+        KidneyExchange.runKidneyExchange(50, hospitals, MatchingAlgorithm.Greedy, false);
         Assertions.assertEquals(hospital1.getSize(), 0);
         Assertions.assertEquals(hospital2.getSize(), 0);
     }

--- a/KidneyExchangeTest/src/KidneyExchangeTest.java
+++ b/KidneyExchangeTest/src/KidneyExchangeTest.java
@@ -1,0 +1,175 @@
+import KidneyExchange.*;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+
+public class KidneyExchangeTest {
+
+    // Test a single round of runKidneyExchange with single hospital
+    @Test
+    public void runKidneyExchangeTest1() {
+        int hospitalId = 0;
+        int pairId = 0;
+        // Create a hospital with 3 surgery slots and add a cycle of length 3
+        Hospital hospital1 = new Hospital(++hospitalId, 3);
+        hospital1.addPair(new ExchangePair(KidneyType.A, KidneyType.B, ++pairId, hospital1.getHospitalId()));
+        hospital1.addPair(new ExchangePair(KidneyType.B, KidneyType.C, ++pairId, hospital1.getHospitalId()));
+        hospital1.addPair(new ExchangePair(KidneyType.C, KidneyType.A, ++pairId, hospital1.getHospitalId()));
+
+        // Run single round of kidney exchange and verify that all patients are removed
+        Hospital[] hospitals = { hospital1 };
+        KidneyExchange.runKidneyExchange(1, hospitals,false);
+        Assertions.assertEquals(hospital1.getSize(), 0);
+
+        // Create another hospital with 2 surgery slots and a cycle of length 3
+        Hospital hospital2 = new Hospital(++hospitalId, 2);
+        hospital2.addPair(new ExchangePair(KidneyType.A, KidneyType.B, ++pairId, hospital2.getHospitalId()));
+        hospital2.addPair(new ExchangePair(KidneyType.B, KidneyType.C, ++pairId, hospital2.getHospitalId()));
+        hospital2.addPair(new ExchangePair(KidneyType.C, KidneyType.A, ++pairId, hospital2.getHospitalId()));
+
+        // Run single round of kidney exchange and verify that no patients are removed
+        hospitals[0] = hospital2;
+        KidneyExchange.runKidneyExchange(1, hospitals, false);
+        Assertions.assertEquals(hospital2.getSize(), 3);
+    }
+
+    // Test three rounds of runKidneyExchange with two hospitals that need to collaborate
+    @Test
+    public void runKidneyExchangeTest2() {
+        int hospitalId = 0;
+        int pairId = 0;
+
+        // Hospital 1 and Hospital 2 contains pairs that cannot be locally matched, but can be globally matched
+        Hospital hospital1 = new Hospital(++hospitalId, 4);
+        hospital1.addPair(new ExchangePair(KidneyType.A, KidneyType.B, ++pairId, hospital1.getHospitalId()));
+        hospital1.addPair(new ExchangePair(KidneyType.C, KidneyType.D, ++pairId, hospital1.getHospitalId()));
+
+        Hospital hospital2 = new Hospital(++hospitalId, 4);
+        hospital2.addPair(new ExchangePair(KidneyType.B, KidneyType.A, ++pairId, hospital2.getHospitalId()));
+        hospital2.addPair(new ExchangePair(KidneyType.D, KidneyType.C, ++pairId, hospital2.getHospitalId()));
+
+        // Neither will be able to match in Round 1, Hospital 1 will acquire pairs in Round 2,
+        // pairs will be matched in Round 3
+        Hospital[] hospitals = { hospital1, hospital2 };
+        KidneyExchange.runKidneyExchange(3, hospitals, false);
+        Assertions.assertEquals(hospital1.getSize(), 0);
+        Assertions.assertEquals(hospital2.getSize(), 0);
+    }
+
+    // Test four rounds of runKidneyExchange with three hospitals and verify that pairs distribute
+    @Test
+    public void runKidneyExchangeTest3() {
+        int hospitalId = 0;
+        int pairId = 0;
+
+        // No matching can complete until Hospital 3 pair is acquired by Hospital 1
+        Hospital hospital1 = new Hospital(++hospitalId, 4);
+        hospital1.addPair(new ExchangePair(KidneyType.A, KidneyType.B, ++pairId, hospital1.getHospitalId()));
+
+        Hospital hospital2 = new Hospital(++hospitalId, 4);
+        hospital2.addPair(new ExchangePair(KidneyType.B, KidneyType.C, ++pairId, hospital2.getHospitalId()));
+
+        Hospital hospital3 = new Hospital(++hospitalId, 4);
+        hospital3.addPair(new ExchangePair(KidneyType.C, KidneyType.A, ++pairId, hospital3.getHospitalId()));
+
+        // No one will be able to match in Round 1, Hospital 1 will acquire Hospital 2 pair in Round 2,
+        // Hospital 1 will acquire Hospital 3 pair in round 3, pairs will be matched in round 4
+        // pairs will be matched in Round 3
+        Hospital[] hospitals = { hospital1, hospital2, hospital3 };
+        KidneyExchange.runKidneyExchange(4, hospitals, false);
+        Assertions.assertEquals(hospital1.getSize(), 0);
+        Assertions.assertEquals(hospital2.getSize(), 0);
+        Assertions.assertEquals(hospital3.getSize(), 0);
+    }
+
+    // Test three rounds of runKidneyExchange and verify that information is distributed when no one can be matched
+    @Test
+    public void runKidneyExchangeTest4() {
+        int hospitalId = 0;
+        int pairId = 0;
+
+        // No matchings can complete due to pair incompatibility
+        Hospital hospital1 = new Hospital(++hospitalId, 4);
+        hospital1.addPair(new ExchangePair(KidneyType.A, KidneyType.B, ++pairId, hospital1.getHospitalId()));
+        hospital1.addPair(new ExchangePair(KidneyType.A, KidneyType.B, ++pairId, hospital1.getHospitalId()));
+
+        Hospital hospital2 = new Hospital(++hospitalId, 4);
+        hospital2.addPair(new ExchangePair(KidneyType.C, KidneyType.D, ++pairId, hospital2.getHospitalId()));
+        hospital2.addPair(new ExchangePair(KidneyType.C, KidneyType.D, ++pairId, hospital2.getHospitalId()));
+
+        Hospital hospital3 = new Hospital(++hospitalId, 4);
+        hospital3.addPair(new ExchangePair(KidneyType.B, KidneyType.D, ++pairId, hospital3.getHospitalId()));
+        hospital3.addPair(new ExchangePair(KidneyType.B, KidneyType.D, ++pairId, hospital3.getHospitalId()));
+
+        // No one will ever be able to match, but by round 3, information will have been fully distributed
+        Hospital[] hospitals = { hospital1, hospital2, hospital3 };
+        KidneyExchange.runKidneyExchange(3, hospitals, false);
+        Assertions.assertEquals(hospital1.getSize(), 6);
+        Assertions.assertEquals(hospital2.getSize(), 4);
+        Assertions.assertEquals(hospital3.getSize(), 2);
+    }
+
+    // Build a more complicated example (two hospitals is sufficient) to test resiliency
+    @Test
+    public void runKidneyExchangeTest5() {
+        int hospitalId = 0;
+        int pairId = 0;
+
+        // Hospital 1 will complete one matching (C,D) <-> (D,C), but needs help breaking 4-cycle up
+        Hospital hospital1 = new Hospital(++hospitalId, 3);
+        hospital1.addPair(new ExchangePair(KidneyType.C, KidneyType.D, ++pairId, hospital1.getHospitalId()));
+        hospital1.addPair(new ExchangePair(KidneyType.D, KidneyType.C, ++pairId, hospital1.getHospitalId()));
+        hospital1.addPair(new ExchangePair(KidneyType.A, KidneyType.B, ++pairId, hospital1.getHospitalId()));
+        hospital1.addPair(new ExchangePair(KidneyType.B, KidneyType.C, ++pairId, hospital1.getHospitalId()));
+        hospital1.addPair(new ExchangePair(KidneyType.C, KidneyType.D, ++pairId, hospital1.getHospitalId()));
+        hospital1.addPair(new ExchangePair(KidneyType.D, KidneyType.A, ++pairId, hospital1.getHospitalId()));
+
+        // Hospital 2 can perform local matching (A,B) <-> (B,A), then can help Hospital 1 with two more matchings
+        Hospital hospital2 = new Hospital(++hospitalId, 3);
+        hospital2.addPair(new ExchangePair(KidneyType.A, KidneyType.B, ++pairId, hospital2.getHospitalId()));
+        hospital2.addPair(new ExchangePair(KidneyType.B, KidneyType.A, ++pairId, hospital2.getHospitalId()));
+        hospital2.addPair(new ExchangePair(KidneyType.D, KidneyType.C, ++pairId, hospital2.getHospitalId()));
+        hospital2.addPair(new ExchangePair(KidneyType.C, KidneyType.B, ++pairId, hospital2.getHospitalId()));
+
+
+        // Round 1: Hospital 1 should match (C,D) <-> (D,C) and be unable to do more
+        //          Hospital 2 should match (A,B) <-> (B,A) and inform Hospital 1 of unmatched pairs
+        // Round 2: Hospital 1 should pull one of (D,C), (C,B)
+        //          Hospital 2 has one patient left and waits for it to be requested
+        // Round 3: Hospital 1 can only perform two surgeries at a time, so will be left with four pairs
+        //          Hospital 2 still waits for remaining pair to be requested
+        Hospital[] hospitals = { hospital1, hospital2 };
+        KidneyExchange.runKidneyExchange(3, hospitals, false);
+        Assertions.assertEquals(hospital1.getSize(), 4);
+        Assertions.assertEquals(hospital2.getSize(), 1);
+    }
+
+    // Build a scale test to prove that algorithm can scale
+    @Test
+    public void runKidneyExchangeScaleTest() {
+        int hospitalId = 0;
+        int pairId = 0;
+
+        // Add pairs that will be matched in Hospital 1 only
+        Hospital hospital1 = new Hospital(++hospitalId, 5);
+        for(int i=0; i < 50; i++) {
+            hospital1.addPair(new ExchangePair(KidneyType.A, KidneyType.B, ++pairId, hospital1.getHospitalId()));
+            hospital1.addPair(new ExchangePair(KidneyType.B, KidneyType.C, ++pairId, hospital1.getHospitalId()));
+            hospital1.addPair(new ExchangePair(KidneyType.C, KidneyType.A, ++pairId, hospital1.getHospitalId()));
+        }
+
+        // No dependencies between Hospital 1 and Hospital 2 so that information will still be distributed, but
+        // patients will not be.
+        Hospital hospital2 = new Hospital(++hospitalId, 4);
+        for(int i=0; i < 50; i++) {
+            hospital2.addPair(new ExchangePair(KidneyType.D, KidneyType.B, ++pairId, hospital2.getHospitalId()));
+            hospital2.addPair(new ExchangePair(KidneyType.B, KidneyType.D, ++pairId, hospital2.getHospitalId()));
+        }
+
+        Hospital[] hospitals = { hospital1, hospital2 };
+        // Hospital 1 will finish after 50 rounds, while Hospital 2 will finish in 25 rounds
+        KidneyExchange.runKidneyExchange(50, hospitals, false);
+        Assertions.assertEquals(hospital1.getSize(), 0);
+        Assertions.assertEquals(hospital2.getSize(), 0);
+    }
+}

--- a/KidneyExchangeTest/src/KidneyExchangeTest.java
+++ b/KidneyExchangeTest/src/KidneyExchangeTest.java
@@ -108,6 +108,7 @@ public class KidneyExchangeTest {
     // Build a more complicated example (two hospitals is sufficient) to test resiliency
     @Test
     public void runKidneyExchangeTest5() {
+        ConsoleLogger.setQuiet(true);
         int hospitalId = 0;
         int pairId = 0;
 
@@ -135,13 +136,15 @@ public class KidneyExchangeTest {
         // Round 3: Hospital 1 can only perform two surgeries at a time, so will be left with four pairs
         //          Hospital 2 still waits for remaining pair to be requested
         Hospital[] hospitals = { hospital1, hospital2 };
-        KidneyExchange.runKidneyExchange(3, hospitals, MatchingAlgorithm.Greedy, false);
+        KidneyExchange.runKidneyExchange(3, hospitals, MatchingAlgorithm.GREEDY, false);
         Assertions.assertEquals(hospital1.getSize(), 4);
         Assertions.assertEquals(hospital2.getSize(), 1);
     }
 
     @Test
     public void runKidneyExchangeTests() {
+        // Suppress console output for tests
+        ConsoleLogger.setQuiet(true);
         for(MatchingAlgorithm matchingAlgorithm: MatchingAlgorithm.values()) {
             runKidneyExchangeTest1(matchingAlgorithm);
             runKidneyExchangeTest2(matchingAlgorithm);
@@ -154,6 +157,8 @@ public class KidneyExchangeTest {
     // Build a scale test to prove that algorithm can scale
     @Test
     public void runKidneyExchangeScaleTest() {
+        // Suppress console output for testing
+        ConsoleLogger.setQuiet(true);
         int hospitalId = 0;
         int pairId = 0;
 
@@ -175,7 +180,7 @@ public class KidneyExchangeTest {
 
         Hospital[] hospitals = { hospital1, hospital2 };
         // Hospital 1 will finish after 50 rounds, while Hospital 2 will finish in 25 rounds
-        KidneyExchange.runKidneyExchange(50, hospitals, MatchingAlgorithm.Greedy, false);
+        KidneyExchange.runKidneyExchange(50, hospitals, MatchingAlgorithm.GREEDY, false);
         Assertions.assertEquals(hospital1.getSize(), 0);
         Assertions.assertEquals(hospital2.getSize(), 0);
     }


### PR DESCRIPTION
Functional Changes:
1. Removed printing of Adjacency List for greedy algorithm as I felt that it was just annoying.
2. Modified Hospital toString method to indicate when `ExchangePair`s belong to hospitals other than the current hospital.
3. Added `incremental` flag to `runKidneyExchange` so that tests were deterministic.
4. Made `runKidneyExchange` public so that it could be invoked by tests.
5. Moved `KidneyType` enum to public so that it could be used in testing.
6. Added visual dashes to denote cycle composition returned by greedy matching algorithm.

Testing:
1. Added 5 test cases that should pass for both algorithms.
*Currently, ILP fails on `runKidneyExchangeTest5` and I am hoping you can figure out why after this merges, as I believe it should behave the same was as the greedy implementation.* I think perhaps we implemented moving pairs differently?
2. Added scale test for Greedy algorithm to show that greedy algorithm scales well.